### PR TITLE
Fix NO_DELAY_EFFECT quirk implementation

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -369,7 +369,9 @@ static void pidff_set_effect_report(struct pidff_device *pidff,
 	pidff->effect_direction->value[0] =
 		pidff_rescale(direction, 0xffff, pidff->effect_direction);
 
-	pidff->set_effect[PID_START_DELAY].value[0] = effect->replay.delay;
+	if (!(pidff->quirks & PIDFF_QUIRK_NO_DELAY_EFFECT)) {
+		pidff->set_effect[PID_START_DELAY].value[0] = effect->replay.delay;
+	}
 
 	hid_hw_request(pidff->hid, pidff->reports[PID_SET_EFFECT],
 			HID_REQ_SET_REPORT);
@@ -814,7 +816,9 @@ static void pidff_autocenter(struct pidff_device *pidff, u16 magnitude)
 	pidff->set_effect[PID_TRIGGER_REPEAT_INT].value[0] = 0;
 	pidff_set(&pidff->set_effect[PID_GAIN], magnitude);
 	pidff->set_effect[PID_DIRECTION_ENABLE].value[0] = 1;
-	pidff->set_effect[PID_START_DELAY].value[0] = 0;
+	if (!(pidff->quirks & PIDFF_QUIRK_NO_DELAY_EFFECT)) {
+		pidff->set_effect[PID_START_DELAY].value[0] = 0;
+	}
 
 	hid_hw_request(pidff->hid, pidff->reports[PID_SET_EFFECT],
 			HID_REQ_SET_REPORT);


### PR DESCRIPTION
Bug was present when moza-ff was created. Moza wheelbases does not need that fix, so PID_START_DELAY field was always present.