### PR TITLE
Add Cammus C12

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ And that's basically it
 ## What devices are supported?
 ### Bases:
 1. MOZA R3, R5, R9, R12, R16, R21
-2. Cammus C5
+2. Cammus C5, C12
 3. ...
 
 ## What works?

--- a/hid-ids.h
+++ b/hid-ids.h
@@ -11,5 +11,6 @@
 
 #define USB_VENDOR_ID_CAMMUS        0x3416
 #define USB_DEVICE_ID_CAMMUS_C5     0x0301
+#define USB_DEVICE_ID_CAMMUS_C12    0x0302
 
 #endif

--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -25,6 +25,8 @@ static const struct hid_device_id pidff_wheel_devices[] = {
 		.driver_data = PIDFF_QUIRK_FIX_WHEEL_DIRECTION },
 	{ HID_USB_DEVICE(USB_VENDOR_ID_CAMMUS, USB_DEVICE_ID_CAMMUS_C5),
 		.driver_data = PIDFF_QUIRK_NO_DELAY_EFFECT },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_CAMMUS, USB_DEVICE_ID_CAMMUS_C12),
+		.driver_data = PIDFF_QUIRK_NO_DELAY_EFFECT },
 	{ }
 };
 MODULE_DEVICE_TABLE(hid, pidff_wheel_devices);


### PR DESCRIPTION
I expected that with Chinese manufacturers (Cammus & Moza), new wheels would be extremely close to each other (hardware and firmware). It seems to be so from what I've seen. 
> Also, from r/simracing and Cammus using old openffboard firmware as the base or something? I don't have any experience in hardware or low-level, so I'll take it with a grain of salt.

## Important stuff
Cammus C12 needs its VID: `0x3416` and PID `0x0302` implemented, same no delay a7 patch, and it should act the same as the Cammus C5. I'm using the latest firmware (1.6.8) and edit wheel settings within the Android app.
> I did not test this with the a7 patch removed, but I doubt it will work without it (like the C5).

I am waiting for the [pull request](https://github.com/libsdl-org/SDL/pull/10510) of the Cammus C12 to SDL to add to the whitelist. I have currently been forcing it on the whitelist within Steam launch options.
```
SDL_JOYSTICK_WHEEL_DEVICES=0x3416/0x0302 %command%
```

Weirdly, issue https://github.com/JacKeTUs/universal-pidff/issues/7 seems to be fine for me. This could be caused by me using the Steam launch option for whitelisting it. 
> You need to define it on the Windows side last time that I saw on the Cammus discord, So I'll leave this here just in case in the future for anyone searching.
```XML
<device official="false" name="cammus_c12_base" type="wheel" id="{03023416-0000-0000-0000-504944564944}" priority="100"/>
```
I looked at the Moza fix and realized it's just the PID and then VID; I don't know what the other numbers mean.
With this being a potential common thing, it would be nice to see it in the readme in either the universal-pidff or the linux-steering-wheels repo.

I've been forcing Steam Input to `off` as well.
Games tested:
* Assetto Corsa (Proton Experimental & GE-Proton 9-7)
* American Truck Simulator (Native, Proton Experimental & GE-Proton 9-7)
* Dirt Rally 2.0 (Proton Experimental & GE-Proton 9-7)

Steering, all buttons (joysticks, paddles, rotors), and force feedback work. 
> Probably would give it a silver like it's C5 on the linux-steering-wheel repo. There is no telemetry; firmware updates need Windows, a7 patch to get it working, etc.

[Forza Horizon 5](https://www.youtube.com/watch?v=VGrkL4mK9MQ) should be looked into. They have a "helper" for it on Windows within Cammus software. I have no interest in the Forza series, so I couldn't test and see if this was still a thing. But this could come up in the future.

I just cloned the repo into /usr/src/, made the tiny edits, and installed it as a dkms.
![image](https://github.com/user-attachments/assets/aa546bc3-b2ed-43b7-a686-c9d9dab88bcb)
> Here's my Linux system for reference ^