### PR TITLE
Defuzz additional axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ And that's basically it
 
 
 ## What does not work?
-1. Telemetry functions (Shift lights, displays, SimHub, etc), mostly because telemetry works only with proprietary soft, which can't get access to shared memory chunks from games.
+1. Telemetry functions. They are handeled by [Monocoque](https://github.com/Spacefreak18/monocoque)
 2. `Firmware Update` function. Use Windows PC or Windows VM at the moment.
-3. Setup through proprietary software. May require [some tweaking](#how-to-set-up-a-base-parameters))
+3. Setup through proprietary software. May require [some tweaking](#how-to-set-up-a-base-parameters)
 
 ## How to install this driver?
 You can install it through AUR package, through DKMS or manually.
@@ -60,6 +60,9 @@ Best for debugging purposes, where you need frequently change codebase/branches
 
 To unload module:
 `sudo rmmod hid_universal_pidff`
+
+### Testing
+To test the supported effects, use ffbplay from [ffbtools](https://github.com/berarma/ffbtools) and play the included [effect-test.ffb](./effect-test.ffb) file
 
 ## How to set up a base parameters?
 ### MOZA

--- a/effect-test.ffb
+++ b/effect-test.ffb
@@ -1,0 +1,67 @@
+00000000 # Constant force left
+00000000 > UPLOAD id:-1 dir:16384 type:CONSTANT level:9000
+00000000 < 0 id:0
+00000000 > PLAY 0 1
+03000000 # Constant force right
+03000000 > UPLOAD id:0 dir:16384 type:CONSTANT level:-9000
+06000000 # Spring
+06000000 > REMOVE 0
+06000000 > UPLOAD id:-1 dir:16384 type:SPRING left_coeff:32767 right_coeff:32767
+06000000 < 0 id:0
+06000000 > PLAY 0 1
+07000000 # Move the wheel yourself to test these next 3 effects
+09000000 > STOP 0
+09000000 # Damper
+09000000 > REMOVE 0
+09000000 > UPLOAD id:-1 dir:16384 type:DAMPER left_coeff:32767 right_coeff:32767
+09000000 < 0 id:0
+09000000 > PLAY 0 1
+12000000 # Friction
+12000000 > STOP 0
+12000000 > REMOVE 0
+12000000 > UPLOAD id:-1 dir:16384 type:FRICTION left_coeff:32767 right_coeff:32767
+12000000 < 0 id:0
+12000000 > PLAY 0 1
+15000000 # Inertia
+15000000 > STOP 0
+15000000 > REMOVE 0
+15000000 > UPLOAD id:-1 dir:16384 type:INERTIA left_coeff:32767 right_coeff:32767
+15000000 < 0 id:0
+15000000 > PLAY 0 1
+18000000 # Periodic sine
+18000000 > REMOVE 0
+18000000 > UPLOAD id:-1 dir:16384 type:PERIODIC waveform:SINE period:100 magnitude:9000
+18000000 < 0 id:0
+18000000 > PLAY 0 1
+21000000 # Periodic square
+21000000 > REMOVE 0
+21000000 > UPLOAD id:-1 dir:16384 type:PERIODIC waveform:SQUARE period:100 magnitude:9000
+21000000 < 0 id:0
+21000000 > PLAY 0 1
+24000000 # Periodic triangle
+24000000 > REMOVE 0
+24000000 > UPLOAD id:-1 dir:16384 type:PERIODIC waveform:TRIANGLE period:100 magnitude:9000
+24000000 < 0 id:0
+24000000 > PLAY 0 1
+27000000 # Periodic saw up
+27000000 > REMOVE 0
+27000000 > UPLOAD id:-1 dir:16384 type:PERIODIC waveform:SAW_UP period:100 magnitude:9000
+27000000 < 0 id:0
+27000000 > PLAY 0 1
+30000000 # Periodic saw down
+30000000 > REMOVE 0
+30000000 > UPLOAD id:-1 dir:16384 type:PERIODIC waveform:SAW_DOWN period:100 magnitude:9000
+30000000 < 0 id:0
+30000000 > PLAY 0 1
+33000000 # Sine constant force emulation left
+33000000 > REMOVE 0
+33000000 > UPLOAD id:-1 dir:16384 type:PERIODIC waveform:SINE period:1000 magnitude:0 offset:12000
+33000000 < 0 id:0
+33000000 > PLAY 0 1
+36000000 # Sine constant force emulation right
+36000000 > UPLOAD id:0 dir:16384 type:PERIODIC waveform:SINE period:1000 magnitude:0 offset:-12000
+39000000 > REMOVE 0
+39000000 # Sine constant force emulation right
+39000000 > UPLOAD id:0 dir:16384 type:PERIODIC waveform:SINE period:1000 magnitude:0 offset:-12000
+42000000 > STOP 0
+42000000 > REMOVE 0

--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -12,9 +12,6 @@
 #include "hid-ids.h"
 #include "hid-pidff.h"
 
-#define MOZA_ADDITIONAL_AXES	{ABS_Y, ABS_Z, ABS_RX, ABS_RY, ABS_RZ, ABS_THROTTLE, ABS_RUDDER}
-#define CAMMUS_ADDITIONAL_AXES	{}
-
 static const struct hid_device_id pidff_wheel_devices[] = {
 	{ HID_USB_DEVICE(USB_VENDOR_ID_MOZA, USB_DEVICE_ID_MOZA_R3),
 		.driver_data = PIDFF_QUIRK_FIX_WHEEL_DIRECTION },
@@ -97,36 +94,15 @@ static int universal_pidff_input_configured(struct hid_device *hdev,
 
 	// Decrease fuzz and deadzone on additional axes
 	// Default Linux values are 255 for fuzz and 4096 for flat (deadzone)
-	short *additional_axes;
-	short moza_axes[] = MOZA_ADDITIONAL_AXES;
-	short cammus_axes[] = CAMMUS_ADDITIONAL_AXES;
-	short axes_cnt = 0;
+	short i;
+	for (i = ABS_Y; i <= ABS_BRAKE, i++) {
+		if (!test_bit(input->absbit, i))
+			continue;
 
-	switch (hdev->vendor)
-	{
-	case USB_VENDOR_ID_MOZA:
-		hid_dbg(hdev, "Defuzzing MOZA wheelbase");
-		additional_axes = moza_axes;
-		axes_cnt = sizeof(moza_axes) / sizeof(moza_axes[0]);
-		break;
-
-	case USB_VENDOR_ID_CAMMUS:
-		hid_dbg(hdev, "Defuzzing CAMMUS wheelbase");
-		additional_axes = cammus_axes;
-		axes_cnt = sizeof(cammus_axes) / sizeof(cammus_axes[0]);
-		break;
-
-	default:
-		break;
+		input_set_abs_params(input, i,
+			input->absinfo[i].minimum,
+			input->absinfo[i].maximum, 8, 16);
 	}
-
-	// Perform defuzzing
-	for (short i = 0; i < axes_cnt; i++)
-		input_set_abs_params(input, additional_axes[i],
-			input->absinfo[additional_axes[i]].minimum,
-			input->absinfo[additional_axes[i]].maximum, 32, 32);
-
-	return 0;
 }
 
 static struct hid_driver universal_pidff = {

--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -94,14 +94,14 @@ static int universal_pidff_input_configured(struct hid_device *hdev,
 
 	// Decrease fuzz and deadzone on additional axes
 	// Default Linux values are 255 for fuzz and 4096 for flat (deadzone)
-	short i;
-	for (i = ABS_Y; i <= ABS_BRAKE, i++) {
-		if (!test_bit(input->absbit, i))
+	short axis;
+	for (axis = ABS_Y; axis <= ABS_BRAKE, axis++) {
+		if (!test_bit(input->absbit, axis))
 			continue;
 
-		input_set_abs_params(input, i,
-			input->absinfo[i].minimum,
-			input->absinfo[i].maximum, 8, 16);
+		input_set_abs_params(input, axis,
+			input->absinfo[axis].minimum,
+			input->absinfo[axis].maximum, 8, 16);
 	}
 }
 


### PR DESCRIPTION
Decrease default fuzz/flat values so additional axes can be more precise. Especially the high default deadzone is a killer.

Add info about Monocoque for telemetry

Include .ffb file for testing all effect types with ffbplay