### PR TITLE
Manually map device buttons to increase button limit from 80 to 138

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To unload module:
 **[Android App](https://play.google.com/store/apps/details?id=com.cammus.simulator)**
 
 ## Known issues with the driver
-- Buttons above 80 simply don't show up. This is a Linux limitation and we're trying to fix that in the upstream
+- Current limit of usable buttons is 138 (up from the Linux default of 80). Create an issue if you want this increased further.
 
 ## Known issues with the firmware
 You tell me please

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To unload module:
 **[Android App](https://play.google.com/store/apps/details?id=com.cammus.simulator)**
 
 ## Known issues with the driver
-- Current limit of usable buttons is 138 (up from the Linux default of 80). Create an issue if you want this increased further.
+- Current limit of usable buttons is 160 (up from the Linux default of 80). Create an issue if you want this increased further.
 
 ## Known issues with the firmware
 You tell me please

--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -4,6 +4,7 @@
  * First of all targeting steering wheels and wheelbases
  *
  * Copyright (c) 2024 Makarenko Oleg
+ * Copyright (c) 2024 Tomasz Pakuła
  */
 
 #include <linux/device.h>
@@ -137,5 +138,6 @@ static struct hid_driver universal_pidff = {
 module_hid_driver(universal_pidff);
 
 MODULE_AUTHOR("Oleg Makarenko <oleg@makarenk.ooo>");
+MODULE_AUTHOR("Tomasz Pakuła <tomasz.pakula.oficjalny@gmail.com>");
 MODULE_DESCRIPTION("Universal HID PIDFF Driver");
 MODULE_LICENSE("GPL");

--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -14,7 +14,6 @@
 #include "hid-ids.h"
 #include "hid-pidff.h"
 
-#define BTN_RANGE (BTN_9 - BTN_0 + 1)
 #define JOY_RANGE (BTN_DEAD - BTN_JOYSTICK + 1)
 
 static const struct hid_device_id pidff_wheel_devices[] = {
@@ -69,15 +68,12 @@ static int universal_pidff_input_mapping(struct hid_device *hdev, struct hid_inp
 		return 0;
 
 	int button = ((usage->hid - 1) & HID_USAGE);
-	int code = button + BTN_0;
-
-	// Detect the end of BTN_* range
-	if (code > BTN_9)
-		code = button + BTN_JOYSTICK - BTN_RANGE;
+	int code = button + BTN_JOYSTICK;
 
 	// Detect the end of JOYSTICK buttons range
+	// KEY_AUDIO_DESC = 0x270
 	if (code > BTN_DEAD)
-		code = button + KEY_MACRO1 - BTN_RANGE - JOY_RANGE;
+		code = button + KEY_NEXT_FAVORITE - JOY_RANGE;
 
 	// Map overflowing buttons to KEY_RESERVED for the upcoming new input event
 	// It will handle button presses differently and won't depend on defined


### PR DESCRIPTION
This PR adds `input_mapping` function that handles button mapping. Everything else falls back to the default hid behavior.

By making use of BTN_* and KEY_MACRO* ranges we're extending the button limit from 80 to 137. If we need more than that, we can just lower the last block of usages to something that comes earlier than KEY_MACRO1.

I also took the courtesy to add myself as the co-author.