### PR TITLE
Fix missing return statement in the `input_configured` function

### DIFF
--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -137,6 +137,8 @@ static int universal_pidff_input_configured(struct hid_device *hdev,
 			input->absinfo[axis].minimum,
 			input->absinfo[axis].maximum, 8, 16);
 	}
+
+	return 0;
 }
 
 static struct hid_driver universal_pidff = {


### PR DESCRIPTION
It's not explicitly needed, but let's stick to the good practices.