### PR TITLE
Set flat value to 0 for additional axes

### DIFF
--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -135,7 +135,7 @@ static int universal_pidff_input_configured(struct hid_device *hdev,
 
 		input_set_abs_params(input, axis,
 			input->absinfo[axis].minimum,
-			input->absinfo[axis].maximum, 8, 16);
+			input->absinfo[axis].maximum, 8, 0);
 	}
 }
 


### PR DESCRIPTION
Flat value (deadzone) works around the center of a given axis. With steering wheels, only the steering axis returns to the center and flat causes weird behavior in the middle of throttle, brake, clutch etc.