### PR TITLE
Fix build for kernels older than 6.12

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
 PACKAGE_NAME="universal-pidff"
-PACKAGE_VERSION="0.0.11"
+PACKAGE_VERSION="0.0.12"
 MAKE[0]="make KVERSION=$kernelver"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="hid-universal-pidff"

--- a/hid-pidff-wrapper.c
+++ b/hid-pidff-wrapper.c
@@ -11,6 +11,7 @@
 #include <linux/hid.h>
 #include <linux/module.h>
 #include <linux/input-event-codes.h>
+#include <linux/version.h>
 #include "hid-ids.h"
 #include "hid-pidff.h"
 
@@ -52,24 +53,32 @@ static const struct hid_device_id pidff_wheel_devices[] = {
 MODULE_DEVICE_TABLE(hid, pidff_wheel_devices);
 
 
-static const u8 *moza_report_fixup(struct hid_device *hdev, __u8 *rdesc,
-				   unsigned int *rsize)
+static
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+const
+#endif
+u8 *moza_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+		      unsigned int *rsize)
 {
 	// Fix data type on PID Device Control
-        if (rdesc[1002] == 0x91 && rdesc[1003] == 0x02) {
+	if (rdesc[1002] == 0x91 && rdesc[1003] == 0x02) {
 		rdesc[1003] = 0x00; // Fix header, it needs to be Array.
-        }
-        return rdesc;
+	}
+	return rdesc;
 }
 
 
-static const u8 *universal_pidff_report_fixup(struct hid_device *hdev, __u8 *rdesc,
-        				      unsigned int *rsize)
+static
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+const
+#endif
+u8 *universal_pidff_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+        			 unsigned int *rsize)
 {
-		if (hdev->vendor == USB_VENDOR_ID_MOZA) {
-			return moza_report_fixup(hdev, rdesc, rsize);
-		}
-		return rdesc;
+	if (hdev->vendor == USB_VENDOR_ID_MOZA) {
+		return moza_report_fixup(hdev, rdesc, rsize);
+	}
+	return rdesc;
 }
 
 /*


### PR DESCRIPTION
Use Kernel version macros to determine if `const` is needed for report fixups

Slight indentation fixes

Fixes #42 completely

Based on: https://github.com/berarma/new-lg4ff/commit/6100a34c182536c607af80e119d54a66c6fb2a23