### PR TITLE
Clamp LOOP_COUNT

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -700,7 +700,8 @@ static void pidff_playback_pid(struct pidff_device *pidff, int pid_id, int n)
 	} else {
 		pidff->effect_operation_status->value[0] =
 			pidff->operation_id[PID_EFFECT_START];
-		pidff->effect_operation[PID_LOOP_COUNT].value[0] = n;
+		pidff->effect_operation[PID_LOOP_COUNT].value[0] = 
+			pidff_clamp(n, pidff->effect_operation[PID_LOOP_COUNT].field);
 	}
 
 	hid_hw_request(pidff->hid, pidff->reports[PID_EFFECT_OPERATION],


### PR DESCRIPTION
Ensures the loop count will never exceed the logical_maximum.

Fixes implementation errors happening when applications use the max value of int32 as the effect iterations.