### PR TITLE
Improve device control

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -145,7 +145,7 @@ static const u8 pidff_block_load_status[] = { 0x8c, 0x8d, 0x8e};
 #define PID_EFFECT_STOP		1
 static const u8 pidff_effect_operation_status[] = { 0x79, 0x7b };
 
-/* Polar direction 90 degrees (North) */
+/* Polar direction 90 degrees (East) */
 #define PIDFF_FIXED_WHEEL_DIRECTION	0x4000
 
 struct pidff_usage {

--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -118,7 +118,9 @@ static const u8 pidff_pool[] = { 0x80, 0x83, 0xa9 };
 #define PID_DISABLE_ACTUATORS	1
 #define PID_STOP_ALL_EFFECTS	2
 #define PID_RESET		3
-static const u8 pidff_device_control[] = { 0x97, 0x98, 0x99, 0x9a };
+#define PID_PAUSE		4
+#define PID_CONTINUE		5
+static const u8 pidff_device_control[] = { 0x97, 0x98, 0x99, 0x9a, 0x9b, 0x9c };
 
 #define PID_CONSTANT	0
 #define PID_RAMP	1
@@ -559,17 +561,24 @@ static void pidff_set_gain_report(struct pidff_device *pidff, u16 gain)
  */
 static void pidff_send_device_control(struct pidff_device *pidff, int field)
 {
-	int i, tmp;
+	int i, index;
 	int field_index = pidff->control_id[field];
+
+	if (field_index < 1)
+		return;
 
 	/* Detect if the field is a bitmask variable or an array */
 	if (pidff->device_control->flags & HID_MAIN_ITEM_VARIABLE) {
 		hid_dbg(pidff->hid, "DEVICE_CONTROL is a bitmask\n");
+
 		/* Clear current bitmask */
 		for(i = 0; i < sizeof(pidff_device_control); i++) {
-			tmp = pidff->control_id[i];
-			hid_dbg(pidff->hid, "Clearing index: %d", tmp);
-			pidff->device_control->value[tmp - 1] = 0;
+			index = pidff->control_id[i];
+			if (index < 1)
+				continue;
+
+			hid_dbg(pidff->hid, "Clearing index: %d", index);
+			pidff->device_control->value[index - 1] = 0;
 		}
 
 		pidff->device_control->value[field_index - 1] = 1;

--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -564,6 +564,10 @@ static void pidff_set_device_control(struct pidff_device *pidff, int field)
 	int i, index;
 	int field_index = pidff->control_id[field];
 
+	/*
+	 * Search is permissive, some fields could be missing
+	 * HID arrays have 1-based indexing
+	 */
 	if (field_index < 1)
 		return;
 
@@ -709,7 +713,7 @@ static void pidff_playback_pid(struct pidff_device *pidff, int pid_id, int n)
 	} else {
 		pidff->effect_operation_status->value[0] =
 			pidff->operation_id[PID_EFFECT_START];
-		pidff->effect_operation[PID_LOOP_COUNT].value[0] = 
+		pidff->effect_operation[PID_LOOP_COUNT].value[0] =
 			pidff_clamp(n, pidff->effect_operation[PID_LOOP_COUNT].field);
 	}
 

--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -557,9 +557,9 @@ static void pidff_set_gain_report(struct pidff_device *pidff, u16 gain)
 }
 
 /*
- * Clear device control report
+ * Send device control report to the device
  */
-static void pidff_send_device_control(struct pidff_device *pidff, int field)
+static void pidff_set_device_control(struct pidff_device *pidff, int field)
 {
 	int i, index;
 	int field_index = pidff->control_id[field];
@@ -594,10 +594,10 @@ static void pidff_send_device_control(struct pidff_device *pidff, int field)
 /*
  * Modify actuators state
  */
-static void pidff_modify_actuators_state(struct pidff_device *pidff, bool enable)
+static void pidff_set_actuators(struct pidff_device *pidff, bool enable)
 {
 	hid_dbg(pidff->hid, "%s actuators\n", enable ? "enable" : "disable");
-	pidff_send_device_control(pidff,
+	pidff_set_device_control(pidff,
 		enable ? PID_ENABLE_ACTUATORS : PID_DISABLE_ACTUATORS);
 }
 
@@ -607,12 +607,12 @@ static void pidff_modify_actuators_state(struct pidff_device *pidff, bool enable
 static void pidff_reset(struct pidff_device *pidff)
 {
 	/* We reset twice as sometimes hid_wait_io isn't waiting long enough */
-	pidff_send_device_control(pidff, PID_RESET);
-	pidff_send_device_control(pidff, PID_RESET);
+	pidff_set_device_control(pidff, PID_RESET);
+	pidff_set_device_control(pidff, PID_RESET);
 	pidff->effect_count = 0;
 
-	pidff_send_device_control(pidff, PID_STOP_ALL_EFFECTS);
-	pidff_modify_actuators_state(pidff, 1);
+	pidff_set_device_control(pidff, PID_STOP_ALL_EFFECTS);
+	pidff_set_actuators(pidff, 1);
 }
 
 /*


### PR DESCRIPTION
The driver doesn't check if all the fields were found, so make sure to omit those not found.

Rename:
```
pidff_send_device_control    -> pidff_set_device_control
pidff_modify_actuators_state -> pidff_set_actuators
```