### PR TITLE
Remove unneeded debug

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -341,10 +341,6 @@ static void pidff_set_envelope_report(struct pidff_device *pidff,
 	pidff_set_time(&pidff->set_envelope[PID_FADE_TIME],
 			envelope->fade_length);
 
-	hid_dbg(pidff->hid, "attack %u => %d\n",
-		envelope->attack_level,
-		pidff->set_envelope[PID_ATTACK_LEVEL].value[0]);
-
 	hid_hw_request(pidff->hid, pidff->reports[PID_SET_ENVELOPE],
 			HID_REQ_SET_REPORT);
 }


### PR DESCRIPTION
We don't need info about envelope attack at this point. If we ever had to debug it again, we'd probably like all the values, not just attack.