### PR TITLE
Add new quirks to fix Asetek conditional effects

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -618,16 +618,19 @@ static void pidff_set_condition_report(struct pidff_device *pidff,
 				 effect->u.condition[i].center);
 		pidff_set_signed(&pidff->set_condition[PID_POS_COEFFICIENT],
 				 effect->u.condition[i].right_coeff);
+		pidff_set(&pidff->set_condition[PID_POS_SATURATION],
+			  effect->u.condition[i].right_saturation);
 
 		/* Omit Negative Coefficient if missing */
 		if (!(pidff->quirks & HID_PIDFF_QUIRK_MISSING_NEG_COEFFICIENT))
 			pidff_set_signed(&pidff->set_condition[PID_NEG_COEFFICIENT],
 					effect->u.condition[i].left_coeff);
 
-		pidff_set(&pidff->set_condition[PID_POS_SATURATION],
-			  effect->u.condition[i].right_saturation);
-		pidff_set(&pidff->set_condition[PID_NEG_SATURATION],
-			  effect->u.condition[i].left_saturation);
+		/* Omit Negative Saturation if missing */
+		if (!(pidff->quirks & HID_PIDFF_QUIRK_MISSING_NEG_SATURATION))
+			pidff_set_signed(&pidff->set_condition[PID_NEG_SATURATION],
+					effect->u.condition[i].left_saturation);
+
 		pidff_set(&pidff->set_condition[PID_DEAD_BAND],
 			  effect->u.condition[i].deadband);
 		hid_hw_request(pidff->hid, pidff->reports[PID_SET_CONDITION],
@@ -1098,6 +1101,9 @@ static int pidff_find_fields(struct pidff_usage *usage, const u8 *table,
 
 		else if (table[i] == pidff_set_condition[PID_NEG_COEFFICIENT])
 			PIDFF_MISSING_FIELD(NEG_COEFFICIENT, quirks);
+
+		else if (table[i] == pidff_set_condition[PID_NEG_SATURATION])
+			PIDFF_MISSING_FIELD(NEG_SATURATION, quirks);
 
 		else if (strict) {
 			pr_debug("failed to locate %d\n", i);

--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -631,8 +631,11 @@ static void pidff_set_condition_report(struct pidff_device *pidff,
 			pidff_set_signed(&pidff->set_condition[PID_NEG_SATURATION],
 					effect->u.condition[i].left_saturation);
 
-		pidff_set(&pidff->set_condition[PID_DEAD_BAND],
-			  effect->u.condition[i].deadband);
+		/* Omit Deadband field if missing */
+		if (!(pidff->quirks & HID_PIDFF_QUIRK_MISSING_DEADBAND))
+			pidff_set(&pidff->set_condition[PID_DEAD_BAND],
+				effect->u.condition[i].deadband);
+
 		hid_hw_request(pidff->hid, pidff->reports[PID_SET_CONDITION],
 			       HID_REQ_SET_REPORT);
 	}
@@ -1104,6 +1107,9 @@ static int pidff_find_fields(struct pidff_usage *usage, const u8 *table,
 
 		else if (table[i] == pidff_set_condition[PID_NEG_SATURATION])
 			PIDFF_MISSING_FIELD(NEG_SATURATION, quirks);
+
+		else if (table[i] == pidff_set_condition[PID_DEAD_BAND])
+			PIDFF_MISSING_FIELD(DEADBAND, quirks);
 
 		else if (strict) {
 			pr_debug("failed to locate %d\n", i);

--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -618,8 +618,12 @@ static void pidff_set_condition_report(struct pidff_device *pidff,
 				 effect->u.condition[i].center);
 		pidff_set_signed(&pidff->set_condition[PID_POS_COEFFICIENT],
 				 effect->u.condition[i].right_coeff);
-		pidff_set_signed(&pidff->set_condition[PID_NEG_COEFFICIENT],
-				 effect->u.condition[i].left_coeff);
+
+		/* Omit Negative Coefficient if missing */
+		if (!(pidff->quirks & HID_PIDFF_QUIRK_MISSING_NEG_COEFFICIENT))
+			pidff_set_signed(&pidff->set_condition[PID_NEG_COEFFICIENT],
+					effect->u.condition[i].left_coeff);
+
 		pidff_set(&pidff->set_condition[PID_POS_SATURATION],
 			  effect->u.condition[i].right_saturation);
 		pidff_set(&pidff->set_condition[PID_NEG_SATURATION],
@@ -1091,6 +1095,9 @@ static int pidff_find_fields(struct pidff_usage *usage, const u8 *table,
 
 		else if (table[i] == pidff_set_condition[PID_PARAM_BLOCK_OFFSET])
 			PIDFF_MISSING_FIELD(PBO, quirks);
+
+		else if (table[i] == pidff_set_condition[PID_NEG_COEFFICIENT])
+			PIDFF_MISSING_FIELD(NEG_COEFFICIENT, quirks);
 
 		else if (strict) {
 			pr_debug("failed to locate %d\n", i);

--- a/hid-pidff.h
+++ b/hid-pidff.h
@@ -41,6 +41,16 @@
  */
 #define HID_PIDFF_QUIRK_PERIODIC_SINE_ONLY	BIT(4)
 
+/*
+ * Windows allows devices with missing negative coefficient for conditional
+ * effects. Negative coefficient is ignored in such cases. Do not fail
+ * set_condition usage search if negative coefficient is missing. Fixes
+ * conditional effect playback on Asetek wheelbases.
+ *
+ * https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ee416601(v=vs.85)
+ */
+#define HID_PIDFF_QUIRK_MISSING_NEG_COEFFICIENT	BIT(5)
+
 /* Kernel ifndef not included as we have our own copy of hid-pidff */
 int hid_pidff_init(struct hid_device *hid);
 int hid_pidff_init_with_quirks(struct hid_device *hid, u32 initial_quirks);

--- a/hid-pidff.h
+++ b/hid-pidff.h
@@ -56,6 +56,13 @@
  */
 #define HID_PIDFF_QUIRK_MISSING_NEG_SATURATION	BIT(6)
 
+/*
+ * Some devices (mainly Asetek) do not have deadband field in set conditional
+ * usage. Do not fail set conditional usage search if it's missing.
+ * Fixes conditional effect playback on Asetek wheelbases.
+ */
+#define HID_PIDFF_QUIRK_MISSING_DEADBAND	BIT(7)
+
 /* Kernel ifndef not included as we have our own copy of hid-pidff */
 int hid_pidff_init(struct hid_device *hid);
 int hid_pidff_init_with_quirks(struct hid_device *hid, u32 initial_quirks);

--- a/hid-pidff.h
+++ b/hid-pidff.h
@@ -51,6 +51,11 @@
  */
 #define HID_PIDFF_QUIRK_MISSING_NEG_COEFFICIENT	BIT(5)
 
+/*
+ * This is the same case as for Negative coefficient
+ */
+#define HID_PIDFF_QUIRK_MISSING_NEG_SATURATION	BIT(6)
+
 /* Kernel ifndef not included as we have our own copy of hid-pidff */
 int hid_pidff_init(struct hid_device *hid);
 int hid_pidff_init_with_quirks(struct hid_device *hid, u32 initial_quirks);


### PR DESCRIPTION
Adds three new quirks which should fix conditional effects on Asetek devices.

MISSING_NEG_COEFFICIENT - Detects missing Negative Coefficient field and skips its assignment.

MISSING_NEG_SATURATION - Same but for negative saturation field.

MISSING_DEADBAND - Same but for deadband field
