### PR TITLE
Fix possible integer overflow in `pidff_rescale()`

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -326,8 +326,9 @@ static s32 pidff_clamp(s32 i, struct hid_field *field)
  */
 static int pidff_rescale(int i, int max, struct hid_field *field)
 {
-	return i * (field->logical_maximum - field->logical_minimum) / max +
-	       field->logical_minimum;
+	/* 64 bits needed for big values during rescale */
+	return (s64)i * (field->logical_maximum - field->logical_minimum) /
+	       max + field->logical_minimum;
 }
 
 /*


### PR DESCRIPTION
Fixes: #116

```
Before:
calculated from 65353 to -29637

After:
calculated from 65353 to 35899
```

No error on effect upload:
<img width="411" height="86" alt="image" src="https://github.com/user-attachments/assets/e72fd5a2-a946-4da5-9ecf-dd5c8ed92778" />

No need for a fix on the signed path as there, the max possible value during rescale fits into 32 bit signed integer.
