### PR TITLE
Include overflow fix from upstream

### DIFF
--- a/hid-pidff.c
+++ b/hid-pidff.c
@@ -11,6 +11,7 @@
 #include "hid-pidff.h"
 #include <linux/hid.h>
 #include <linux/input.h>
+#include <linux/math64.h>
 #include <linux/minmax.h>
 #include <linux/slab.h>
 #include <linux/stringify.h>
@@ -327,8 +328,9 @@ static s32 pidff_clamp(s32 i, struct hid_field *field)
 static int pidff_rescale(int i, int max, struct hid_field *field)
 {
 	/* 64 bits needed for big values during rescale */
-	return (s64)i * (field->logical_maximum - field->logical_minimum) /
-	       max + field->logical_minimum;
+	s64 result = field->logical_maximum - field->logical_minimum;
+
+	return div_s64(result * i, max) + field->logical_minimum;
 }
 
 /*


### PR DESCRIPTION
The previous fix caused build errors on 32 bit machines and ARM machines. This one uses kernel-provided 64bit division that works on all architectures.